### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# SYNOPSIS 
+# SYNOPSIS
 [![NPM Package](https://img.shields.io/npm/v/wasm-json-toolkit.svg?style=flat-square)](https://www.npmjs.org/package/wasm-json-toolkit)
 [![Build Status](https://img.shields.io/travis/ewasm/wasm-json-toolkit.svg?branch=master&style=flat-square)](https://travis-ci.org/ewasm/wasm-json-toolkit)
 [![Coverage Status](https://img.shields.io/coveralls/ewasm/wasm-json-toolkit.svg?style=flat-square)](https://coveralls.io/r/ewasm/wasm-json-toolkit)
 
-[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)  
+[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
-A small toolkit for converting wasm binaries into json and back. 
+A small toolkit for converting wasm binaries into json and back.
 
 # INSTALL
 `npm install wasm-json-toolkit`
@@ -24,8 +24,8 @@ console.log(JSON.stringify(json, null, 2))
 # CLI
 Install `-g` global for cli usage.
 
-`wasm2json [FILE]` given a file containing a wasm module produces a json representation  
-`json2wasm [FILE]` given a file containing a json representation produces a wasm module  
+`wasm2json [FILE]` given a file containing a wasm module produces a json representation
+`json2wasm [FILE]` given a file containing a json representation produces a wasm module
 
 # API
 # wasm2json
@@ -37,7 +37,7 @@ converts a wasm binary into a json representation
 -  `Buffer` - The Webassembly Binary
 -  `filter` - `Set` containing the name of sections to parse. If no filter is given all sections will be parsed
 
-Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
 # json2wasm
 
@@ -45,9 +45,9 @@ converts a json representation to a wasm binary
 
 **Parameters**
 
--   `Object`  
+-   `Object`
 
-Returns **[Buffer](https://nodejs.org/api/buffer.html)** 
+Returns **[Buffer](https://nodejs.org/api/buffer.html)**
 
 # text2json
 
@@ -55,7 +55,7 @@ converts text to json. The only text accepted is a simple list of opcode name an
 
 **Parameters**
 
--   `String`  
+-   `String`
 
 **Examples**
 
@@ -68,7 +68,7 @@ i64.add
 const json = text2json(codeStr)
 ```
 
-Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
 # iterator
 
@@ -92,7 +92,7 @@ for (const section of it) {
 
 [iterator.js:26-32](https://github.com/ewasm/wasm-json-toolkit/blob/e9fdd9498451b39b84c1167e78dc4aad03b055bd/iterator.js#L26-L32 "Source code on GitHub")
 
-if the orignal wasm module was modified then this will return the modified
+if the original wasm module was modified then this will return the modified
 wasm module
 
 ## iterator
@@ -107,14 +107,14 @@ return {Iterator.<Section>}
 [iterator.js:64-110](https://github.com/ewasm/wasm-json-toolkit/blob/e9fdd9498451b39b84c1167e78dc4aad03b055bd/iterator.js#L64-L110 "Source code on GitHub")
 
 The section class is always internal created by the Module class. And return
-through the Module's iternator
+through the Module's iterator
 
 
 ## toJSON
 
 [iterator.js:83-85](https://github.com/ewasm/wasm-json-toolkit/blob/e9fdd9498451b39b84c1167e78dc4aad03b055bd/iterator.js#L83-L85 "Source code on GitHub")
 
-Parses the section and return the JSON repesentation of it
+Parses the section and return the JSON representation of it
 returns {Object}
 
 ## appendEntries
@@ -126,10 +126,10 @@ parent wasm module.
 
 **Parameters**
 
--   `entries` **Arrayy&lt;[Buffer](https://nodejs.org/api/buffer.html)>** 
+-   `entries` **Array&lt;[Buffer](https://nodejs.org/api/buffer.html)>**
 
 
-## exammple json output
+## example json output
 
 wast
 ```
@@ -150,7 +150,7 @@ json
 ```
 [
   {
-    "name": "preramble",
+    "name": "preamble",
     "magic": [0,97,115,109],
     "version": [13,0,0,0]
   },
@@ -186,11 +186,11 @@ json
         "code": [
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "1"
+            "immediates": "1"
           },
           {
             "return_type": "i32",

--- a/example/out.json
+++ b/example/out.json
@@ -1,7 +1,7 @@
 0061736d0d00000001070160027f7f017f03020100070a010661646454776f00000a09010700200020016a0b
 [
   {
-    "name": "preramble",
+    "name": "preamble",
     "magic": [
       0,
       97,
@@ -52,11 +52,11 @@
         "code": [
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "1"
+            "immediates": "1"
           },
           {
             "return_type": "i32",

--- a/iterator.js
+++ b/iterator.js
@@ -21,7 +21,7 @@ module.exports = class ModuleIterator {
   }
 
   /**
-   * if the orignal wasm module was modified then this will return the modified
+   * if the original wasm module was modified then this will return the modified
    * wasm module
    */
   get wasm () {
@@ -60,7 +60,7 @@ module.exports = class ModuleIterator {
 
 /**
  * The section class is always internal created by the Module class. And return
- * through the Module's iternator
+ * through the Module's iterator
  */
 class Section {
   constructor (sectionType, section, it, index) {
@@ -78,7 +78,7 @@ class Section {
   }
 
   /**
-   * Parses the section and return the JSON repesentation of it
+   * Parses the section and return the JSON representation of it
    * returns {Object}
    */
   toJSON () {
@@ -88,7 +88,7 @@ class Section {
   /**
    * Appends an array of entries to this section. NOTE: this will modify the
    * parent wasm module.
-   * @param {Arrayy.<Buffer>} entries
+   * @param {Array.<Buffer>} entries
    */
   appendEntries (entries) {
     this.count += entries.length

--- a/json2wasm.js
+++ b/json2wasm.js
@@ -15,7 +15,7 @@ const LANGUAGE_TYPES = _exports.LANGUAGE_TYPES = {
   'i64': 0x7e,
   'f32': 0x7d,
   'f64': 0x7c,
-  'anyFunc': 0x70,
+  'anyfunc': 0x70,
   'func': 0x60,
   'block_type': 0x40
 }
@@ -241,7 +241,7 @@ _exports.typeGenerators = {
    */
   memory: (json, stream) => {
     leb.unsigned.write(Number(json.maximum !== undefined), stream) // the flags
-    leb.unsigned.write(json.intial, stream)
+    leb.unsigned.write(json.initial, stream)
 
     if (json.maximum !== undefined) {
       leb.unsigned.write(json.maximum, stream)
@@ -420,7 +420,7 @@ _exports.generateSection = function (json, stream = new Stream()) {
 
 _exports.generate = (json, stream = new Stream()) => {
   const [ preamble, ...rest ] = json
-  _exports.generatePreramble(preamble, stream)
+  _exports.generatePreamble(preamble, stream)
   for (let item of rest) {
     _exports.generateSection(item, stream)
   }
@@ -428,7 +428,7 @@ _exports.generate = (json, stream = new Stream()) => {
   return stream
 }
 
-_exports.generatePreramble = (json, stream = new Stream()) => {
+_exports.generatePreamble = (json, stream = new Stream()) => {
   stream.write(json.magic)
   stream.write(json.version)
   return stream

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-json-toolkit",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-json-toolkit",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "this convertes wasm binaries to json and json to wasm binaries",
   "main": "index.js",
   "scripts": {

--- a/test/address.json
+++ b/test/address.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "preramble",
+    "name": "preamble",
     "magic": [
       0,
       97,
@@ -37,7 +37,7 @@
     "entries": [
       {
         "flags": 0,
-        "intial": 1
+        "initial": 1
       }
     ]
   },
@@ -64,211 +64,211 @@
         "code": [
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load8_u",
-            "immediaties": {
+            "immediates": {
               "flags": 0,
               "offset": 0
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load8_u",
-            "immediaties": {
+            "immediates": {
               "flags": 0,
               "offset": 1
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load8_u",
-            "immediaties": {
+            "immediates": {
               "flags": 0,
               "offset": 2
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load8_u",
-            "immediaties": {
+            "immediates": {
               "flags": 0,
               "offset": 25
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load16_u",
-            "immediaties": {
+            "immediates": {
               "flags": 1,
               "offset": 0
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load16_u",
-            "immediaties": {
+            "immediates": {
               "flags": 0,
               "offset": 0
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load16_u",
-            "immediaties": {
+            "immediates": {
               "flags": 0,
               "offset": 1
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load16_u",
-            "immediaties": {
+            "immediates": {
               "flags": 1,
               "offset": 2
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load16_u",
-            "immediaties": {
+            "immediates": {
               "flags": 0,
               "offset": 25
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load",
-            "immediaties": {
+            "immediates": {
               "flags": 2,
               "offset": 0
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load",
-            "immediaties": {
+            "immediates": {
               "flags": 0,
               "offset": 1
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load",
-            "immediaties": {
+            "immediates": {
               "flags": 1,
               "offset": 2
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load",
-            "immediaties": {
+            "immediates": {
               "flags": 0,
               "offset": 25
             }
           },
           {
             "name": "call",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "name": "end"
@@ -280,12 +280,12 @@
         "code": [
           {
             "name": "get_local",
-            "immediaties": "0"
+            "immediates": "0"
           },
           {
             "return_type": "i32",
             "name": "load",
-            "immediaties": {
+            "immediates": {
               "flags": 2,
               "offset": 4294967295
             }

--- a/test/customSection.js
+++ b/test/customSection.js
@@ -5,7 +5,7 @@ const wasm2json = require('../wasm2json')
 
 const wasm = fs.readFileSync(`${__dirname}/customSection.wasm`)
 const expectedJson = [{
-  'name': 'preramble',
+  'name': 'preamble',
   'magic': [
     0,
     97,

--- a/wasm2json.js
+++ b/wasm2json.js
@@ -14,7 +14,7 @@ const LANGUAGE_TYPES = _exports.LANGUAGE_TYPES = {
   0x7e: 'i64',
   0x7d: 'f32',
   0x7c: 'f64',
-  0x70: 'anyFunc',
+  0x70: 'anyfunc',
   0x60: 'func',
   0x40: 'block_type'
 }
@@ -28,9 +28,9 @@ const EXTERNAL_KIND = _exports.EXTERNAL_KIND = {
   3: 'global'
 }
 
-_exports.parsePreramble = (stream) => {
+_exports.parsePreamble = (stream) => {
   const obj = {}
-  obj.name = 'preramble'
+  obj.name = 'preamble'
   obj.magic = [...stream.read(4)]
   obj.version = [...stream.read(4)]
   return obj
@@ -339,7 +339,7 @@ _exports.typeParsers = {
   memory: (stream) => {
     const limits = {}
     limits.flags = leb.unsigned.readBn(stream).toNumber()
-    limits.intial = leb.unsigned.readBn(stream).toNumber()
+    limits.initial = leb.unsigned.readBn(stream).toNumber()
     if (limits.flags === 1) {
       limits.maximum = leb.unsigned.readBn(stream).toNumber()
     }
@@ -606,8 +606,8 @@ _exports.parseOp = (stream) => {
 }
 
 _exports.parse = (stream, filter) => {
-  const preramble = _exports.parsePreramble(stream)
-  const json = [preramble]
+  const preamble = _exports.parsePreamble(stream)
+  const json = [preamble]
 
   while (!stream.end) {
     const header = _exports.parseSectionHeader(stream)


### PR DESCRIPTION
Renames a few variables like `preramble`, which may break backwards incompatability